### PR TITLE
Added info about C# port.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ console.log(die.roll()) // keep using the same instance
 ### Other Languages
 
 The community has ported this to
-[Java (@eukaryote31)](https://github.com/eukaryote31/gamblers-dice), [Elm (@solkaz)](https://github.com/solkaz/elm-gamblers-dice) and [Python (@torvaney)](https://github.com/Torvaney/gamblers-dice). Check them out
+[Java (@eukaryote31)](https://github.com/eukaryote31/gamblers-dice), [Elm (@solkaz)](https://github.com/solkaz/elm-gamblers-dice), [Python (@torvaney)](https://github.com/Torvaney/gamblers-dice), and [C# (@MrTarantula)](https://github.com/mrtarantula/gamblers-dice). Check them out
 if these are your languages of choice!
 
 ## I don't get it


### PR DESCRIPTION
I created a C# port of gamblers-dice. It's a .Net Standard 2.0 library. It includes a gambler's die and a fair die (inspired by the Java port). There are also 3 constructors:

* `GamblersDie()` - default 6-sided die
* `GamblersDie(#)` - die with # sides
* `GamblersDie([#, #, #, #])` - die with the x sides where x is array length, and each side has # weight. 

The third constructor can accept an array or just multiple integers (called [params](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/params) in C#, [rest parameters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) in JS). I did this so I can persist the state to storage (which I call weight in my port). I also made the weight publicly accessible for this reason.